### PR TITLE
fix reading from process when using python3

### DIFF
--- a/lib_users_util/common.py
+++ b/lib_users_util/common.py
@@ -83,6 +83,7 @@ def query_systemctl(pid, output=None):
         pcomm = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         output, _ = pcomm.communicate()
+        output = output.decode(sys.stdin.encoding)
     if "No unit for PID %s is loaded." % (pid) in output:
         return None
     header = output.split("\n")[0]

--- a/lib_users_util/test_common.py
+++ b/lib_users_util/test_common.py
@@ -177,7 +177,14 @@ class Testsystemdintegration(unittest.TestCase):
 
             def communicate(self):
                 """...with a lock"""
-                return("● sshd.service - OpenSSH Daemon", "stderr sez dat")
+                return(self._encode_stdin("● sshd.service - OpenSSH Daemon"),
+                       self._encode_stdin("stderr sez dat"))
+
+            def _encode_stdin(self, value):
+                if sys.version_info >= (3, 0):
+                    return value.encode(sys.stdin.encoding)
+                else:
+                    return value
 
         return mock_proc()
 


### PR DESCRIPTION
In python3 the output returned by communicate() will by bytes which
cannot be checked if something is "in" it in the next line, resulting in
a TypeError ("Type str doesn't support the buffer API") at runtime

(Tested with python 2.7, 3.4, and 3.5 and ran the nose tests with 3.5, running the tests with 2.7 was not possible for me without further modification even before I made the changes in the PR. I had to remove the reassignment of sys.stderr.write and use the mock-backport, but then the tests also ran with 2.7)