### PR TITLE
Fix error handling of systemctl status process

### DIFF
--- a/lib_users_util/common.py
+++ b/lib_users_util/common.py
@@ -88,8 +88,10 @@ def query_systemctl(pid, output=None):
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         output, _ = pcomm.communicate()
         output = output.decode(sys.stdin.encoding or "utf-8")
-    if "No unit for PID %s is loaded." % (pid) in output:
-        return None
+
+        if pcomm.returncode:
+            return None
+
     header = output.split("\n")[0]
     fields = header.split("-")[0].split()
     if len(fields) == 1:


### PR DESCRIPTION
At least on one system using Python 3.8 the error output of `systemctl status
[pid]` would not be written to the output variable. Also the output of
systemctl (version 246) apparantly changed to

"Failed to get unit for PID [pid]: PID [pid] does not belong to any loaded
unit."

Therefore I think it is better to check the return code of the `systemctl status`
process and if it is non-zero, return None.

This was the output of lib_users 0.14 on the affected system. I think `bpfilter_umh` is some Kernel process or something.

```
# lib_users --services
3524 "bpfilter_umh"

Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.8/lib_users", line 133, in <module>
    main(sys.argv[1:])
  File "/usr/lib/python-exec/python3.8/lib_users", line 129, in main
    print(common.get_services(users))
  File "/usr/lib/python3.8/site-packages/lib_users_util/common.py", line 114, in get_services
    unit = query_systemctl(pid)
  File "/usr/lib/python3.8/site-packages/lib_users_util/common.py", line 100, in query_systemctl
    svc = fields[1]
IndexError: list index out of range
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/klausman/lib_users/7)
<!-- Reviewable:end -->
